### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/Readme.md
+++ b/Readme.md
@@ -27,3 +27,5 @@ Than go to user scripts and create a new script that runs daily/weekls with
 #!/bin/bash
 docker run --rm -v /mnt/user/appdata/nextcloud_securipy:/ncsecuripy frolvlad/alpine-python3 sh /ncsecuripy/run.sh
 ```
+###Test on Repl.it
+[![Run on Repl.it](https://repl.it/badge/github/maschhoff/nextcloud_securipy)](https://repl.it/github/maschhoff/nextcloud_securipy)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).